### PR TITLE
Added package class loader so jars do not clash with other packages.

### DIFF
--- a/RMOA/pkg/R/AAA.R
+++ b/RMOA/pkg/R/AAA.R
@@ -1,1 +1,3 @@
 MOA_interfaces <- new.env()
+
+

--- a/RMOA/pkg/R/Classification.R
+++ b/RMOA/pkg/R/Classification.R
@@ -28,7 +28,7 @@ MOA_classifier <- function(model, control=NULL, ...){
   class(out) <- c(model, "MOA_classifier", "MOA_model")
   out$type <- model
   ## Create the model
-  out$moamodel <- .jnew(modelclass(out$type))  
+  out$moamodel <- .jnew(modelclass(out$type), class.loader=.rJava.class.loader)  
   ## Set MOA options
   if(inherits(control, "MOAmodelOptions")){
     if(control$model != out$type){

--- a/RMOA/pkg/R/MOAinstances.R
+++ b/RMOA/pkg/R/MOAinstances.R
@@ -24,7 +24,7 @@ MOAattributes.data.frame <- function(data, ...){
   }
   
   nrattributes <- as.integer(ncol(data))
-  attributes <- .jnew("java.util.ArrayList", nrattributes)
+  attributes <- .jnew("java.util.ArrayList", nrattributes, class.loader=.rJava.class.loader)
   levs <- list()
   allattributes <- list()
   for(attr in names(data)){    
@@ -35,9 +35,9 @@ MOAattributes.data.frame <- function(data, ...){
       levs[[attr]] <- character(0)
     }    
     if(inherits(data[[attr]], "factor")){
-      att <- .jnew("weka/core/Attribute", attr, as.java.util.List(alllevels))
+      att <- .jnew("weka/core/Attribute", attr, as.java.util.List(alllevels), class.loader=.rJava.class.loader)
     }else{
-      att <- .jnew("weka/core/Attribute", attr)      
+      att <- .jnew("weka/core/Attribute", attr, class.loader=.rJava.class.loader)      
     }
     attributes$add(att)
     allattributes[[attr]] <- att
@@ -63,7 +63,7 @@ attribute.MOAmodelAttributes <- function(x, value){
 ## Create a java.util.List from a vector
 ## @param x a vector (of characters e.g.)
 as.java.util.List <- function(x){
-  l <- .jnew("java.util.ArrayList", as.integer(length(x)))
+  l <- .jnew("java.util.ArrayList", as.integer(length(x)), class.loader=.rJava.class.loader)
   done <- sapply(seq_along(x), FUN=function(i) l$add(i-1L, x[i]))  
   .jcast(l, "java.util.List")
 }

--- a/RMOA/pkg/R/MOAmodeloptions.R
+++ b/RMOA/pkg/R/MOAmodeloptions.R
@@ -70,7 +70,7 @@
 #' MOAoptions(model = "BaselinePredictor")
 MOAoptions <- function(model, ...){
   if(inherits(model, "character")){
-    moamodel <- .jnew(modelclass(model))  
+    moamodel <- .jnew(modelclass(model), class.loader=.rJava.class.loader)  
   }else{
     moamodel <- model$moamodel
     model <- model$type

--- a/RMOA/pkg/R/Recommenders.R
+++ b/RMOA/pkg/R/Recommenders.R
@@ -25,7 +25,7 @@ MOA_recommender <- function(model, control=NULL, ...){
   class(out) <- c(model, "MOA_recommender", "MOA_model")
   out$type <- model
   ## Create the model
-  out$moamodel <- .jnew(modelclass(out$type))  
+  out$moamodel <- .jnew(modelclass(out$type), class.loader=.rJava.class.loader)  
   ## Set MOA options
   if(inherits(control, "MOAmodelOptions")){
     if(control$model != out$type){

--- a/RMOA/pkg/R/Regression.R
+++ b/RMOA/pkg/R/Regression.R
@@ -30,7 +30,7 @@ MOA_regressor <- function(model, control=NULL, ...){
   class(out) <- c(model, "MOA_regressor", "MOA_model")
   out$type <- model
   ## Create the model
-  out$moamodel <- .jnew(modelclass(out$type))  
+  out$moamodel <- .jnew(modelclass(out$type), class.loader=.rJava.class.loader)  
   ## Set MOA options
   if(inherits(control, "MOAmodelOptions")){
     if(control$model != out$type){

--- a/RMOA/pkg/R/onLoad.R
+++ b/RMOA/pkg/R/onLoad.R
@@ -1,0 +1,7 @@
+
+# get the class loader from RMOAjars
+.onLoad <- function(libname, pkgname){
+  .rJava.class.loader <- .jclassLoader(package="RMOAjars")
+  assign(".rJava.class.loader", .rJava.class.loader, envir = parent.env(environment()))
+}
+

--- a/RMOA/pkg/R/train.R
+++ b/RMOA/pkg/R/train.R
@@ -81,11 +81,11 @@ trainMOA.MOA_classifier <- function(model, formula, data, subset, na.action=na.e
   setmodelcontext <- function(model, data, response){
     # build the weka instances structure
     atts <- MOAattributes(data=data)
-    allinstances <- .jnew("weka.core.Instances", "data", atts$columnattributes, 0L)
+    allinstances <- .jnew("weka.core.Instances", "data", atts$columnattributes, 0L, class.loader=.rJava.class.loader)
     ## Set the response data to predict    
     .jcall(allinstances, "V", "setClass", attribute(atts, response)$attribute)
     ## Prepare for usage
-    .jcall(model$moamodel, "V", "setModelContext", .jnew("moa.core.InstancesHeader", allinstances))
+    .jcall(model$moamodel, "V", "setModelContext", .jnew("moa.core.InstancesHeader", allinstances, class.loader=.rJava.class.loader))
     .jcall(model$moamodel, "V", "prepareForUse")
     list(model = model, allinstances = allinstances)
   }
@@ -94,7 +94,7 @@ trainMOA.MOA_classifier <- function(model, formula, data, subset, na.action=na.e
     traindata <- as.train(traindata)
     ## Loop over the data and train
     for(j in 1:nrow(traindata)){
-      oneinstance <- .jnew("weka/core/DenseInstance", 1.0, .jarray(as.double(traindata[j, ])))  
+      oneinstance <- .jnew("weka/core/DenseInstance", 1.0, .jarray(as.double(traindata[j, ])), class.loader=.rJava.class.loader)  
       .jcall(oneinstance, "V", "setDataset", allinstances)
       oneinstance <- .jcast(oneinstance, "weka/core/Instance")
       .jcall(model$moamodel, "V", "trainOnInstance", oneinstance)
@@ -213,11 +213,11 @@ trainMOA.MOA_regressor <- function(model, formula, data, subset, na.action=na.ex
   setmodelcontext <- function(model, data, response){
     # build the weka instances structure
     atts <- MOAattributes(data=data)
-    allinstances <- .jnew("weka.core.Instances", "data", atts$columnattributes, 0L)
+    allinstances <- .jnew("weka.core.Instances", "data", atts$columnattributes, 0L, class.loader=.rJava.class.loader)
     ## Set the response data to predict    
     .jcall(allinstances, "V", "setClass", attribute(atts, response)$attribute)
     ## Prepare for usage
-    .jcall(model$moamodel, "V", "setModelContext", .jnew("moa.core.InstancesHeader", allinstances))
+    .jcall(model$moamodel, "V", "setModelContext", .jnew("moa.core.InstancesHeader", allinstances, class.loader=.rJava.class.loader))
     .jcall(model$moamodel, "V", "prepareForUse")
     list(model = model, allinstances = allinstances)
   }
@@ -226,7 +226,7 @@ trainMOA.MOA_regressor <- function(model, formula, data, subset, na.action=na.ex
     traindata <- as.train(traindata)
     ## Loop over the data and train
     for(j in 1:nrow(traindata)){
-      oneinstance <- .jnew("weka/core/DenseInstance", 1.0, .jarray(as.double(traindata[j, ])))  
+      oneinstance <- .jnew("weka/core/DenseInstance", 1.0, .jarray(as.double(traindata[j, ])), class.loader=.rJava.class.loader)  
       .jcall(oneinstance, "V", "setDataset", allinstances)
       oneinstance <- .jcast(oneinstance, "weka/core/Instance")
       .jcall(model$moamodel, "V", "trainOnInstance", oneinstance)
@@ -500,7 +500,7 @@ predict.MOA_trainedmodel <- function(object, newdata, type="response", transFUN=
     newdata <- as.train(newdata[, columnnames$attribute.names, drop = FALSE])
     
     atts <- MOAattributes(data=newdata)
-    allinstances <- .jnew("weka.core.Instances", "data", atts$columnattributes, 0L)
+    allinstances <- .jnew("weka.core.Instances", "data", atts$columnattributes, 0L, class.loader=.rJava.class.loader)
     .jcall(allinstances, "V", "setClass", attribute(atts, columnnames$response)$attribute)
     
     if(inherits(object, "MOA_classifier")){
@@ -509,7 +509,7 @@ predict.MOA_trainedmodel <- function(object, newdata, type="response", transFUN=
       scores <- matrix(nrow = nrow(newdata), ncol = 1)
     }  
     for(j in 1:nrow(newdata)){
-      oneinstance <- .jnew("weka/core/DenseInstance", 1.0, .jarray(as.double(newdata[j, ])))  
+      oneinstance <- .jnew("weka/core/DenseInstance", 1.0, .jarray(as.double(newdata[j, ])), class.loader=.rJava.class.loader)  
       .jcall(oneinstance, "V", "setDataset", allinstances)
       oneinstance <- .jcast(oneinstance, "weka/core/Instance")
       if(inherits(object, "MOA_classifier")){

--- a/RMOAjars/pkg/DESCRIPTION
+++ b/RMOAjars/pkg/DESCRIPTION
@@ -8,7 +8,7 @@ Description: External jars required for package RMOA. RMOA is a framework to
 Depends:
     R (>= 2.6.0)
 Imports:
-    rJava (>= 0.6-3)
+    rJava (>= 1.0-1)
 SystemRequirements: Java (>= 5.0)
 License: GPL-3
 Copyright: See file COPYRIGHTS

--- a/RMOAjars/pkg/R/onLoad.R
+++ b/RMOAjars/pkg/R/onLoad.R
@@ -1,5 +1,5 @@
 #' @importFrom rJava .jpackage
 .onLoad <- function(libname, pkgname){
-  .jpackage(pkgname, lib.loc = libname)
+  .jpackage(pkgname, lib.loc = libname, own.loader = TRUE)
 }
-    
+


### PR DESCRIPTION
Hi Jan,

Packages using `rJava` clash if the jars share fully classified class names. Since `rJava` 1.0-1 package specific class loaders are available and encouraged. To be able to use `RMOA` and `streamMOA` at the same time, I have added the recommended class loader to your packages. Instances are now created using `.jnew("myClass", class.loader=.rJava.class.loader)`. 

The new `onLoad.R` in `RMOA` retrieves the class loader from `RMOAjars`.

Best,
Michael